### PR TITLE
fix(FilePublicSessionKeyStore): Include nodeId in scope

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     // Align versions of all Kotlin components
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
 
-    api("tech.relaycorp:awala:[1.66.4,2.0.0)")
+    api("tech.relaycorp:awala:[1.68.2,2.0.0)")
     testImplementation("tech.relaycorp:awala-testing:1.5.24")
 
     implementation("org.mongodb:bson:4.11.0")

--- a/src/main/kotlin/tech/relaycorp/awala/keystores/file/FileSessionPublicKeystore.kt
+++ b/src/main/kotlin/tech/relaycorp/awala/keystores/file/FileSessionPublicKeystore.kt
@@ -17,13 +17,17 @@ public class FileSessionPublicKeystore(
     @Suppress("MemberVisibilityCanBePrivate")
     public val rootDirectory: File = keystoreRoot.directory.resolve("public")
 
-    override suspend fun saveKeyData(keyData: SessionPublicKeyData, peerId: String) {
+    override suspend fun saveKeyData(
+        keyData: SessionPublicKeyData,
+        nodeId: String,
+        peerId: String
+    ) {
         val wasDirectoryCreated = rootDirectory.mkdirs()
         if (!wasDirectoryCreated && !rootDirectory.exists()) {
             throw FileKeystoreException("Failed to create root directory for public keys")
         }
 
-        val keyDataFile = getKeyDataFile(peerId)
+        val keyDataFile = getKeyDataFile(nodeId, peerId)
         val bsonSerialization = BasicOutputBuffer().use { buffer ->
             BsonBinaryWriter(buffer).use {
                 it.writeStartDocument()
@@ -41,8 +45,8 @@ public class FileSessionPublicKeystore(
         }
     }
 
-    override suspend fun retrieveKeyData(peerId: String): SessionPublicKeyData? {
-        val keyDataFile = getKeyDataFile(peerId)
+    override suspend fun retrieveKeyData(nodeId: String, peerId: String): SessionPublicKeyData? {
+        val keyDataFile = getKeyDataFile(nodeId, peerId)
         val serialization = try {
             keyDataFile.readBytes()
         } catch (exc: IOException) {
@@ -66,11 +70,11 @@ public class FileSessionPublicKeystore(
         return data
     }
 
-    override suspend fun delete(peerId: String) {
-        val keyDataFile = getKeyDataFile(peerId)
+    override suspend fun delete(nodeId: String, peerId: String) {
+        val keyDataFile = getKeyDataFile(nodeId, peerId)
         keyDataFile.delete()
     }
 
-    private fun getKeyDataFile(peerId: String) =
-        rootDirectory.resolve(peerId)
+    private fun getKeyDataFile(nodeId: String, peerId: String) =
+        rootDirectory.resolve("$nodeId-$peerId")
 }


### PR DESCRIPTION
See: https://github.com/relaycorp/awala-jvm/pull/306
