### PR TITLE
fix(FilePrivateKeyStore): Include nodeId in scope

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     // Align versions of all Kotlin components
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
 
-    api("tech.relaycorp:awala:[1.68.2,2.0.0)")
+    api("tech.relaycorp:awala:[1.68.5,2.0.0)")
     testImplementation("tech.relaycorp:awala-testing:1.5.26")
 
     implementation("org.mongodb:bson:4.11.1")

--- a/src/main/kotlin/tech/relaycorp/awala/keystores/file/FilePrivateKeyStore.kt
+++ b/src/main/kotlin/tech/relaycorp/awala/keystores/file/FilePrivateKeyStore.kt
@@ -116,14 +116,15 @@ public abstract class FilePrivateKeyStore(keystoreRoot: FileKeystoreRoot) : Priv
      * Delete all the private keys associated with [peerId].
      */
     @Throws(FileKeystoreException::class)
-    override suspend fun deleteSessionKeysForPeer(peerId: String) {
-        val deletionSucceeded = getNodeDirectories()
-            ?.map { it.resolve("session").resolve(peerId) }
-            ?.filter(File::exists)
-            ?.map(File::deleteRecursively)
-            ?.all { it }
-        if (deletionSucceeded == false) {
-            throw FileKeystoreException("Failed to delete all keys for peer $peerId")
+    override suspend fun deleteBoundSessionKeys(nodeId: String, peerId: String) {
+        val deletionSucceeded = getNodeSubdirectory(nodeId)
+            .resolve("session")
+            .resolve(peerId)
+            .deleteRecursively()
+        if (!deletionSucceeded) {
+            throw FileKeystoreException(
+                "Failed to delete session keys for node $nodeId and peer $peerId"
+            )
         }
     }
 }

--- a/src/test/kotlin/tech/relaycorp/awala/keystores/file/FilePrivateKeyStoreTest.kt
+++ b/src/test/kotlin/tech/relaycorp/awala/keystores/file/FilePrivateKeyStoreTest.kt
@@ -367,9 +367,9 @@ class FilePrivateKeyStoreTest : KeystoreTestCase() {
     }
 
     @Nested
-    inner class DeleteSessionKeysForPeer {
+    inner class DeleteBoundSessionKeys {
         @Test
-        fun `Keys linked to peer should be deleted across all nodes`() = runTest {
+        fun `Keys linked to peer should not be deleted from other nodes`() = runTest {
             val keystore = MockFilePrivateKeyStore(keystoreRoot)
             keystore.saveSessionKey(
                 sessionKeypair.privateKey,
@@ -391,10 +391,10 @@ class FilePrivateKeyStoreTest : KeystoreTestCase() {
                 .toPath()
             assertTrue(boundSessionKey2FilePath.exists())
 
-            keystore.deleteSessionKeysForPeer(peerId)
+            keystore.deleteBoundSessionKeys(privateId, peerId)
 
             assertFalse(boundSessionKeyFilePath.parent.exists())
-            assertFalse(boundSessionKey2FilePath.parent.exists())
+            assertTrue(boundSessionKey2FilePath.parent.exists())
         }
 
         @Test
@@ -409,7 +409,7 @@ class FilePrivateKeyStoreTest : KeystoreTestCase() {
                 peer2PrivateAddress,
             )
 
-            keystore.deleteSessionKeysForPeer(peerId)
+            keystore.deleteBoundSessionKeys(privateId, peerId)
 
             keystore.retrieveSessionKey(
                 peer2SessionKeypair.sessionKey.keyId,
@@ -434,7 +434,7 @@ class FilePrivateKeyStoreTest : KeystoreTestCase() {
                 privateId,
             )
 
-            keystore.deleteSessionKeysForPeer(peerId)
+            keystore.deleteBoundSessionKeys(privateId, peerId)
 
             assertThrows<MissingKeyException> {
                 keystore.retrieveSessionKey(
@@ -454,7 +454,7 @@ class FilePrivateKeyStoreTest : KeystoreTestCase() {
         fun `Nothing should happen if the root directory doesn't exist`() = runTest {
             val keystore = MockFilePrivateKeyStore(keystoreRoot)
 
-            keystore.deleteSessionKeysForPeer(peerId)
+            keystore.deleteBoundSessionKeys(privateId, peerId)
         }
 
         @Test
@@ -470,11 +470,11 @@ class FilePrivateKeyStoreTest : KeystoreTestCase() {
             boundSessionKeyFilePath.parent.toFile().setWritable(false)
 
             val exception = assertThrows<FileKeystoreException> {
-                keystore.deleteSessionKeysForPeer(peerId)
+                keystore.deleteBoundSessionKeys(privateId, peerId)
             }
 
             assertEquals(
-                "Failed to delete all keys for peer $peerId",
+                "Failed to delete session keys for node $privateId and peer $peerId",
                 exception.message
             )
         }


### PR DESCRIPTION
See: https://github.com/relaycorp/awala-jvm/issues/310